### PR TITLE
Test: temporarily run only macOS Python 3.13 to isolate crash

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,15 +69,15 @@ jobs:
 
       - name: Build Python package (macOS with CoreML)
         if: runner.os == 'macOS'
-        run: maturin build --features python,onnx-runtime,coreml-runtime --out dist
+        run: maturin build --features onnx-runtime,coreml-runtime --out dist
 
       - name: Build Python package (Linux)
         if: runner.os == 'Linux'
-        run: maturin build --features python,onnx-runtime --out dist
+        run: maturin build --features onnx-runtime --out dist
 
       - name: Build Python package (Windows)
         if: runner.os == 'Windows'
-        run: maturin build --features python,onnx-runtime --out dist
+        run: maturin build --features onnx-runtime --out dist
 
       - name: Install built package
         shell: bash

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,11 @@ setup:
 
 dev: setup
 	@echo "Building and installing pywebnn in development mode..."
-	. $(VENV_ACTIVATE) && maturin develop
+	@if [ "$$(uname)" = "Darwin" ]; then \
+		. $(VENV_ACTIVATE) && maturin develop --features onnx-runtime,coreml-runtime; \
+	else \
+		. $(VENV_ACTIVATE) && maturin develop --features onnx-runtime; \
+	fi
 	@echo "Development installation complete"
 
 build:


### PR DESCRIPTION
Investigating CoreML crash that occurs in CI but not locally. Want to determine if the issue is Python version-specific.