### PR TITLE
ci: install protoc in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,11 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Install protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Install maturin
         run: pip install maturin
 


### PR DESCRIPTION
webnn-onnx-utils 0.1.1's build script invokes prost-build to compile ONNX protos, which requires the protoc compiler. The macOS runner does not ship with protoc, so the wheel build failed with:

  failed to compile ONNX protos with prost-build:
  Could not find `protoc`.

Add the arduino/setup-protoc action before maturin runs so all three runners (ubuntu, macos, windows) have protoc on PATH.